### PR TITLE
Implement watchlist dashboard with real-time APIs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,8 @@
+# Finnhub 免費 API 金鑰
+FINNHUB_API_KEY=your_finnhub_api_key
+
+# 快取存活時間（毫秒）
+CACHE_TTL_MS=60000
+
+# 可選：允許的股票代號清單
+# ALLOWLIST_SYMBOLS=AAPL,MSFT,TSLA

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+.DS_Store
+.env.local
+npm-debug.log*
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,92 @@
-# Codex-Test
+# 自選股即時儀表板
+
+Next.js（App Router）打造的即時自選股儀表板，每分鐘自動更新報價、支援分時走勢 Modal、告警規則、URL 分享與深色介面。伺服器端提供 Finnhub 主來源與 Yahoo 備援，並內建 60 秒記憶體快取。
+
+## 功能總覽
+
+- 📈 自選清單表格：代號、最新價、漲跌幅、資料來源，並支援排序、搜尋、增刪。
+- 🔁 每 60 秒自動輪詢，支援錯誤退避與頁面隱藏暫停。
+- 🪟 Modal 走勢圖：1D/5D 分時折線圖，切換即時拉取 `/api/candles`。
+- 🚨 告警中心：建立價格高於/低於告警，觸發時顯示通知、行內高亮與可選音效。
+- 💾 Local Storage 同步自選與告警清單，URL Query `?symbols=` 支援分享。
+- 🌓 深色模式、鍵盤操作（J/K/Enter/Esc）與 ARIA 對焦狀態。
+
+## 快速開始
+
+```bash
+npm install
+npm run dev
+```
+
+開發伺服器預設執行於 `http://localhost:3000`。
+
+### 環境變數
+
+建立 `.env.local` 並參考 `.env.local.example`：
+
+- `FINNHUB_API_KEY`：Finnhub 免費金鑰（若留空則改用 Yahoo 備援）。
+- `CACHE_TTL_MS`：記憶體快取毫秒數（預設 60000）。
+- `ALLOWLIST_SYMBOLS`：可選，限制允許查詢的代號清單。
+
+### 範例分享網址
+
+```
+http://localhost:3000/?symbols=AAPL,MSFT,TSLA,NVDA
+```
+
+首次載入時會將 Query 參數併入 Local Storage，後續開啟相同網址即可同步自選清單。
+
+## 測試與品質
+
+| 指令 | 說明 |
+| ---- | ---- |
+| `npm run lint` | ESLint 規則檢查 |
+| `npm run test:unit` | Vitest 單元測試（快取、資料處理） |
+| `npm run test:integration` | API 行為整合測試（快取與回退） |
+| `npm run test:e2e` | React Testing Library 端對端互動測試 |
+
+> 提示：若首次安裝於 CI，請記得執行 `npm install` 以取得 Playwright/MSW 等測試依賴。
+
+## API 端點
+
+### `GET /api/quotes`
+
+- `symbols`: 逗號分隔代號（上限 50）。
+- 回傳：`quotes[]`（含 `symbol`, `price`, `prevClose`, `ts`, `source`, `status`）、`ts`, `cached`。
+- 快取：對同一批 `symbols` 以 `CACHE_TTL_MS` 快取，來源失敗時回傳快取並標記。
+
+### `GET /api/candles`
+
+- `symbol`: 單一代號。
+- `range`: `1d` 或 `5d`。
+- 回傳：`candles[]`（OHLCV）、`source`，失敗時 `502` 並回傳空陣列。
+
+## 前端互動重點
+
+- 列點擊→開啟 Modal，支援 Esc 關閉與 1D/5D 切換。
+- 每次更新若價位上/下漲，列會有短暫動畫；資料來源顯示 `finnhub` / `yahoo` / `cache`。
+- 告警觸發時以 Toast、列高亮與音效提示，可於右上角切換靜音。
+- 鍵盤：`J/K` 上下、`Enter` 開啟、`Esc` 關閉 Modal。
+
+## 驗收清單
+
+- [x] `/api/quotes` Finnhub 主來源 + Yahoo 備援 + 60 秒快取。
+- [x] `/api/candles` 支援 1D/5D，失敗時回傳 502 與空資料。
+- [x] 自選清單 CRUD、排序、搜尋、快取狀態提示。
+- [x] 每分鐘輪詢 + 錯誤退避（60s → 120s → 180s）。
+- [x] Modal 走勢圖 Canvas 版面，含資料來源標示。
+- [x] 告警中心、音效、Toast 通知與本地持久化。
+- [x] URL 分享、Local Storage 同步、深色模式。
+- [x] 測試腳本（單元 / 整合 / E2E）與 README 說明。
+- [x] Demo 錄製指引（`docs/demo.md`）。
+
+## 已知限制與後續規劃
+
+- Finnhub 免費額度有限，建議在生產環境提高 `CACHE_TTL_MS` 或預先批次抓取。
+- Yahoo 非官方 API，若結構調整需於伺服器端加強解析錯誤保護。
+- 尚未區分交易時段（盤前/盤後），後續可加入時區與休市判斷。
+- 走勢圖為自製簡易 Canvas，若需求擴大可改用 Chart.js / Recharts。
+
+## Demo 錄影
+
+請參考 [`docs/demo.md`](docs/demo.md) 完成錄影或 GIF，並將產出檔案放入 `docs/assets/` 後更新本段落連結。

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,21 @@
+# Demo 錄製指引
+
+以下流程可協助團隊成員錄製 1 ~ 2 分鐘的操作 Demo（建議輸出為 GIF 或 MP4）：
+
+1. 於專案根目錄執行 `npm install` 與 `npm run dev`，確認開發伺服器啟動於 `http://localhost:3000`。
+2. 開啟螢幕錄製工具（例如 macOS QuickTime、Windows Xbox Game Bar 或開源的 OBS Studio）。
+3. 錄製以下操作流程：
+   - 新增 2 檔股票（示例：`NVDA`、`AMD`）。
+   - 等待輪詢更新，觀察價位變動動畫與資料來源提示。
+   - 點擊任一列開啟 Modal，切換 1D/5D 走勢並滑動滑鼠檢視。
+   - 建立一則價格告警，並於「告警中心」看到記錄。
+   - 觸發告警（可暫時調整價格閾值以快速觸發），確認通知與音效。
+   - 點擊「分享連結」並於瀏覽器開啟新分頁驗證 URL。
+4. 錄製完成後，將影片壓縮為 1280x720 以下並上傳至共享空間。
+5. 若需 GIF，可使用 `ffmpeg` 或 `imagemagick` 將 MP4 轉換：
+   ```bash
+   ffmpeg -i input.mp4 -vf "fps=15,scale=1280:-1:flags=lanczos" demo.gif
+   ```
+6. 將最終檔案放置於 `docs/assets/` 目錄並於 README 中更新連結。
+
+> 備註：若錄製過程中外部 API 無法回應，可先於 `.env.local` 移除 `FINNHUB_API_KEY`，系統會自動切換到 Yahoo 備援並顯示快取狀態。

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "watchlist-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest",
+    "test:unit": "vitest run src/__tests__/unit",
+    "test:integration": "vitest run src/__tests__/integration",
+    "test:e2e": "vitest run src/__tests__/e2e"
+  },
+  "dependencies": {
+    "@headlessui/react": "^1.7.18",
+    "@heroicons/react": "^2.1.5",
+    "@tanstack/react-query": "^5.52.0",
+    "clsx": "^2.0.0",
+    "next": "^14.2.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zustand": "^4.5.2",
+    "zod": "^3.23.8",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.18",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.4",
+    "msw": "^2.4.5",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5",
+    "vitest": "^1.5.2",
+    "@types/uuid": "^9.0.8"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/__tests__/e2e/watchlist.test.tsx
+++ b/src/__tests__/e2e/watchlist.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { WatchlistDashboard } from "@/components/watchlist/watchlist-dashboard";
+import type { QuotesResponse, CandlesResponse } from "@/lib/types";
+
+describe("WatchlistDashboard", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    queryClient = new QueryClient();
+    vi.stubGlobal("fetch", createFetchStub());
+    vi.stubGlobal("AudioContext", class {
+      createOscillator() {
+        return { connect: () => {}, start: () => {}, stop: () => {} };
+      }
+      createGain() {
+        return { connect: () => {}, gain: { setValueAtTime: () => {}, exponentialRampToValueAtTime: () => {} } };
+      }
+      get destination() {
+        return {};
+      }
+      get currentTime() {
+        return 0;
+      }
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("allows adding symbol and opening modal", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WatchlistDashboard initialSymbols={["AAPL"]} />
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("自選股儀表板")).toBeInTheDocument();
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("輸入股票代號"), {
+      target: { value: "MSFT" },
+    });
+    fireEvent.click(screen.getByText("新增"));
+
+    await waitFor(() => expect(screen.getAllByText(/MSFT|AAPL/).length).toBeGreaterThan(1));
+
+    fireEvent.click(screen.getByText("AAPL"));
+    expect(await screen.findByText("1D")).toBeInTheDocument();
+  });
+});
+
+function createFetchStub() {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/api/quotes")) {
+      const payload: QuotesResponse & { cached: boolean } = {
+        quotes: [
+          {
+            symbol: "AAPL",
+            price: 150,
+            prevClose: 145,
+            ts: Date.now(),
+            source: "finnhub",
+            status: "ok",
+          },
+          {
+            symbol: "MSFT",
+            price: 320,
+            prevClose: 310,
+            ts: Date.now(),
+            source: "finnhub",
+            status: "ok",
+          },
+        ],
+        ts: Date.now(),
+        cached: false,
+      };
+      return Promise.resolve({ ok: true, json: async () => payload });
+    }
+    if (url.includes("/api/candles")) {
+      const payload: CandlesResponse & { cached: boolean } = {
+        candles: [
+          { t: Date.now(), o: 150, h: 151, l: 149, c: 150 },
+          { t: Date.now() + 60_000, o: 150, h: 152, l: 148, c: 151 },
+        ],
+        source: "finnhub",
+        cached: false,
+      };
+      return Promise.resolve({ ok: true, json: async () => payload });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+}

--- a/src/__tests__/integration/quotes.test.ts
+++ b/src/__tests__/integration/quotes.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getQuotes } from "@/lib/quotes";
+import cache from "@/lib/cache";
+
+const FINNHUB_URL = "https://finnhub.io/api/v1/quote";
+const YAHOO_URL = "https://query1.finance.yahoo.com/v7/finance/quote";
+
+describe("getQuotes", () => {
+  beforeEach(() => {
+    cache.clear();
+    vi.resetAllMocks();
+    delete process.env.FINNHUB_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    cache.clear();
+  });
+
+  it("falls back to yahoo when finnhub key missing", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.startsWith(YAHOO_URL)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            quoteResponse: {
+              result: [
+                {
+                  symbol: "AAPL",
+                  regularMarketPrice: 190.1,
+                  regularMarketPreviousClose: 188.5,
+                  regularMarketTime: 1700000000,
+                },
+              ],
+            },
+          }),
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getQuotes(["AAPL"]);
+    expect(result.quotes[0].price).toBeCloseTo(190.1);
+    expect(result.quotes[0].source).toBe("yahoo");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches repeated requests", async () => {
+    process.env.FINNHUB_API_KEY = "test";
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.startsWith(FINNHUB_URL)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ c: 10, pc: 9, t: 1700000000, s: "ok" }),
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await getQuotes(["TSLA"]);
+    const second = await getQuotes(["TSLA"]);
+    expect(first.quotes[0].price).toBe(10);
+    expect(second.cached).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/unit/cache.test.ts
+++ b/src/__tests__/unit/cache.test.ts
@@ -1,0 +1,27 @@
+import cache from "@/lib/cache";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+describe("MemoryCache", () => {
+  beforeEach(() => {
+    cache.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cache.clear();
+  });
+
+  it("returns cached value before expiration", () => {
+    cache.set("key", { foo: "bar" }, 1000);
+    const entry = cache.get<{ foo: string }>("key");
+    expect(entry?.value.foo).toBe("bar");
+  });
+
+  it("expires after ttl", () => {
+    cache.set("key", 42, 1000);
+    vi.advanceTimersByTime(1500);
+    const entry = cache.get<number>("key");
+    expect(entry).toBeUndefined();
+  });
+});

--- a/src/__tests__/unit/symbols.test.ts
+++ b/src/__tests__/unit/symbols.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSymbols, sanitizeSymbols, validateSymbol } from "@/lib/symbols";
+
+describe("symbols", () => {
+  it("normalizes comma separated list", () => {
+    expect(normalizeSymbols("aapl, Msft ,aapl")).toEqual(["AAPL", "MSFT"]);
+  });
+
+  it("sanitizes invalid characters", () => {
+    expect(sanitizeSymbols(["AAPL", "BAD#", "MSFT"])).toEqual(["AAPL", "MSFT"]);
+  });
+
+  it("validates allowed pattern", () => {
+    expect(validateSymbol("TSLA")).toBe(true);
+    expect(validateSymbol("$BAD")).toBe(false);
+  });
+});

--- a/src/app/api/candles/route.ts
+++ b/src/app/api/candles/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+import { getCandles } from "@/lib/candles";
+import type { CandlesResponse } from "@/lib/types";
+
+const VALID_RANGES = new Set(["1d", "5d"]);
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const symbol = searchParams.get("symbol")?.toUpperCase();
+  const range = (searchParams.get("range") ?? "1d").toLowerCase();
+  if (!symbol) {
+    return Response.json({ error: "symbol parameter is required" }, { status: 400 });
+  }
+  if (!VALID_RANGES.has(range)) {
+    return Response.json({ error: "range must be 1d or 5d" }, { status: 400 });
+  }
+
+  try {
+    const data = await getCandles(symbol, range as "1d" | "5d");
+    return Response.json<CandlesResponse & { cached: boolean }>(data);
+  } catch (err) {
+    return Response.json(
+      {
+        candles: [],
+        source: "none",
+        error: (err as Error).message,
+      },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from "next/server";
+import { getQuotes } from "@/lib/quotes";
+import { normalizeSymbols } from "@/lib/symbols";
+import type { QuotesResponse } from "@/lib/types";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const rawSymbols = searchParams.get("symbols");
+  if (!rawSymbols) {
+    return Response.json(
+      { error: "symbols parameter is required" },
+      { status: 400 }
+    );
+  }
+  const symbols = normalizeSymbols(rawSymbols);
+  if (symbols.length === 0) {
+    return Response.json(
+      { quotes: [], ts: Date.now(), cached: false },
+      { status: 200 }
+    );
+  }
+
+  try {
+    const data = await getQuotes(symbols);
+    return Response.json<QuotesResponse & { cached: boolean }>({
+      ...data,
+      cached: data.cached,
+    });
+  } catch (err) {
+    return Response.json(
+      {
+        error: (err as Error).message,
+        quotes: [],
+        ts: Date.now(),
+        cached: false,
+      },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,38 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  background-color: #0b1220;
+  color: #f5f7ff;
+  min-height: 100%;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-track {
+  background-color: rgba(255, 255, 255, 0.05);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import "./globals.css";
+import type { Metadata } from "next";
+import { ReactQueryProvider } from "@/components/providers/query-client-provider";
+import { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "自選股即時儀表板",
+  description: "每分鐘更新的自選股追蹤與告警儀表板",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="zh-Hant" className="dark">
+      <body className="bg-background text-slate-100">
+        <ReactQueryProvider>{children}</ReactQueryProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,13 @@
+import { normalizeSymbols } from "@/lib/symbols";
+import { WatchlistDashboard } from "@/components/watchlist/watchlist-dashboard";
+
+interface PageProps {
+  searchParams: { symbols?: string };
+}
+
+export default function Page({ searchParams }: PageProps) {
+  const initialSymbols = searchParams.symbols
+    ? normalizeSymbols(searchParams.symbols)
+    : ["AAPL", "MSFT", "TSLA"];
+  return <WatchlistDashboard initialSymbols={initialSymbols} />;
+}

--- a/src/components/alerts/alert-center.tsx
+++ b/src/components/alerts/alert-center.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { BellAlertIcon, CheckCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import clsx from "clsx";
+import type { AlertRule } from "@/lib/types";
+
+interface AlertCenterProps {
+  alerts: AlertRule[];
+  onToggle: (id: string, active: boolean) => void;
+  onRemove: (id: string) => void;
+}
+
+export function AlertCenter({ alerts, onToggle, onRemove }: AlertCenterProps) {
+  return (
+    <section className="mt-6 rounded-xl border border-slate-700 bg-surface/80 p-4">
+      <header className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-200">
+          <BellAlertIcon className="h-5 w-5" />
+          告警中心
+        </div>
+        <span className="text-xs text-slate-400">共 {alerts.length} 條規則</span>
+      </header>
+      <div className="mt-4 space-y-3">
+        {alerts.length === 0 && (
+          <p className="text-sm text-slate-400">尚未建立任何告警。</p>
+        )}
+        {alerts.map((alert) => (
+          <article
+            key={alert.id}
+            className={clsx(
+              "flex items-center justify-between rounded-lg border px-3 py-2 text-sm",
+              alert.active
+                ? "border-slate-600 bg-slate-800/60"
+                : "border-emerald-600/40 bg-emerald-900/30"
+            )}
+          >
+            <div className="flex items-center gap-2">
+              {alert.triggeredAt ? (
+                <CheckCircleIcon className="h-5 w-5 text-emerald-400" />
+              ) : (
+                <BellAlertIcon className="h-5 w-5 text-amber-400" />
+              )}
+              <div>
+                <div className="font-medium text-slate-100">
+                  {alert.symbol} {alert.direction === "above" ? "≥" : "≤"} {alert.target}
+                </div>
+                <div className="text-xs text-slate-400">
+                  <span className="block">建立：{new Date(alert.createdAt).toLocaleString()}</span>
+                  {alert.triggeredAt && (
+                    <span className="block">
+                      觸發：{new Date(alert.triggeredAt).toLocaleString()}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                className={clsx(
+                  "rounded-md px-2 py-1 text-xs font-medium",
+                  alert.active
+                    ? "bg-slate-700 text-slate-200 hover:bg-slate-600"
+                    : "bg-emerald-700 text-emerald-50 hover:bg-emerald-600"
+                )}
+                onClick={() => onToggle(alert.id, !alert.active)}
+              >
+                {alert.active ? "停用" : "啟用"}
+              </button>
+              <button
+                className="rounded-md bg-slate-700 px-2 py-1 text-xs text-slate-200 hover:bg-slate-600"
+                onClick={() => onRemove(alert.id)}
+                aria-label="移除告警"
+              >
+                <XMarkIcon className="h-4 w-4" />
+              </button>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/alerts/create-alert-form.tsx
+++ b/src/components/alerts/create-alert-form.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+
+interface CreateAlertFormProps {
+  symbol: string;
+  onSubmit: (direction: "above" | "below", target: number) => void;
+  onCancel: () => void;
+}
+
+export function CreateAlertForm({ symbol, onSubmit, onCancel }: CreateAlertFormProps) {
+  const [direction, setDirection] = useState<"above" | "below">("above");
+  const [target, setTarget] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const numeric = Number(target);
+        if (!Number.isFinite(numeric)) {
+          setError("請輸入有效數值");
+          return;
+        }
+        setError(null);
+        onSubmit(direction, numeric);
+      }}
+    >
+      <p className="text-sm text-slate-300">為 {symbol} 建立告警規則。</p>
+      <div className="flex gap-4">
+        <label className="flex items-center gap-2 text-sm text-slate-300">
+          <input
+            type="radio"
+            name="direction"
+            value="above"
+            checked={direction === "above"}
+            onChange={() => setDirection("above")}
+            className="h-4 w-4"
+          />
+          價格高於
+        </label>
+        <label className="flex items-center gap-2 text-sm text-slate-300">
+          <input
+            type="radio"
+            name="direction"
+            value="below"
+            checked={direction === "below"}
+            onChange={() => setDirection("below")}
+            className="h-4 w-4"
+          />
+          價格低於
+        </label>
+      </div>
+      <div>
+        <input
+          type="number"
+          step="0.01"
+          value={target}
+          onChange={(event) => setTarget(event.target.value)}
+          className="w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-slate-100 focus:border-accent focus:outline-none"
+          placeholder="輸入目標價格"
+        />
+      </div>
+      {error && <p className="text-sm text-rose-400">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-slate-600 px-4 py-2 text-sm text-slate-200 hover:bg-slate-700"
+        >
+          取消
+        </button>
+        <button
+          type="submit"
+          className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+        >
+          建立
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/candles-chart.tsx
+++ b/src/components/candles-chart.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { Candle } from "@/lib/types";
+
+interface CandlesChartProps {
+  candles: Candle[];
+}
+
+export function CandlesChart({ candles }: CandlesChartProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    const width = canvas.width;
+    const height = canvas.height;
+    context.clearRect(0, 0, width, height);
+    if (candles.length === 0) {
+      context.fillStyle = "rgba(255,255,255,0.6)";
+      context.font = "16px sans-serif";
+      context.fillText("暫無資料", width / 2 - 40, height / 2);
+      return;
+    }
+    const values = candles.map((c) => c.c);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min || 1;
+    context.lineWidth = 2;
+    context.strokeStyle = "#4f83ff";
+    context.beginPath();
+    candles.forEach((candle, index) => {
+      const x = (index / (candles.length - 1)) * (width - 20) + 10;
+      const y = height - ((candle.c - min) / range) * (height - 20) - 10;
+      if (index === 0) {
+        context.moveTo(x, y);
+      } else {
+        context.lineTo(x, y);
+      }
+    });
+    context.stroke();
+  }, [candles]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={800}
+      height={320}
+      className="w-full rounded-lg border border-slate-700 bg-[#0f172a]"
+      role="img"
+      aria-label="分時走勢圖"
+    />
+  );
+}

--- a/src/components/providers/query-client-provider.tsx
+++ b/src/components/providers/query-client-provider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useEffect, useState } from "react";
+
+function createClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+        retry: 1,
+        staleTime: 30_000,
+      },
+    },
+  });
+}
+
+export function ReactQueryProvider({ children }: { children: ReactNode }) {
+  const [client] = useState(() => createClient());
+
+  useEffect(() => {
+    return () => {
+      client.clear();
+    };
+  }, [client]);
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/src/components/toast-stack.tsx
+++ b/src/components/toast-stack.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface Toast {
+  id: string;
+  title: string;
+  message: string;
+}
+
+interface ToastStackProps {
+  toasts: Toast[];
+  onDismiss: (id: string) => void;
+}
+
+export function ToastStack({ toasts, onDismiss }: ToastStackProps) {
+  useEffect(() => {
+    const timers = toasts.map((toast) =>
+      setTimeout(() => onDismiss(toast.id), 4_000)
+    );
+    return () => timers.forEach((timer) => clearTimeout(timer));
+  }, [onDismiss, toasts]);
+
+  return (
+    <div className="fixed right-6 top-6 z-50 flex w-72 flex-col gap-3">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className="rounded-xl border border-emerald-500/60 bg-slate-900/90 p-4 shadow-lg"
+        >
+          <h3 className="text-sm font-semibold text-emerald-200">{toast.title}</h3>
+          <p className="text-xs text-slate-300">{toast.message}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Dialog, Transition } from "@headlessui/react";
+import { Fragment, ReactNode } from "react";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: ReactNode;
+  children: ReactNode;
+}
+
+export function Modal({ open, onClose, title, children }: ModalProps) {
+  return (
+    <Transition appear show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/70" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-3xl transform overflow-hidden rounded-2xl bg-surface p-6 text-left shadow-xl transition-all">
+                {title && (
+                  <Dialog.Title className="text-lg font-semibold text-slate-100">
+                    {title}
+                  </Dialog.Title>
+                )}
+                <div className="mt-4 text-slate-200">{children}</div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/src/components/watchlist/quote-table.tsx
+++ b/src/components/watchlist/quote-table.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import {
+  ArrowTrendingDownIcon,
+  ArrowTrendingUpIcon,
+  BellAlertIcon,
+  TrashIcon,
+} from "@heroicons/react/24/outline";
+import clsx from "clsx";
+import { formatChange, formatPercent, formatPrice, formatTimestamp, getChange } from "@/lib/format";
+import type { AlertRule, Quote } from "@/lib/types";
+
+interface QuoteTableProps {
+  quotes: Quote[];
+  onSelect: (symbol: string) => void;
+  onRemove: (symbol: string) => void;
+  onCreateAlert: (symbol: string) => void;
+  alerts: Record<string, AlertRule[]>;
+}
+
+export function QuoteTable({ quotes, onSelect, onRemove, onCreateAlert, alerts }: QuoteTableProps) {
+  const [focusIndex, setFocusIndex] = useState(0);
+  const [flashes, setFlashes] = useState<Record<string, "up" | "down" | null>>({});
+  const prevPrices = useRef(new Map<string, number>());
+  const timeoutRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+
+  useEffect(() => {
+    quotes.forEach((quote) => {
+      const prev = prevPrices.current.get(quote.symbol);
+      if (Number.isFinite(quote.price) && typeof prev === "number" && prev !== quote.price) {
+        const direction = quote.price > prev ? "up" : "down";
+        setFlashes((current) => ({ ...current, [quote.symbol]: direction }));
+        const timer = setTimeout(() => {
+          setFlashes((current) => ({ ...current, [quote.symbol]: null }));
+        }, 800);
+        const prevTimer = timeoutRef.current.get(quote.symbol);
+        if (prevTimer) clearTimeout(prevTimer);
+        timeoutRef.current.set(quote.symbol, timer);
+      }
+      if (Number.isFinite(quote.price)) {
+        prevPrices.current.set(quote.symbol, quote.price);
+      }
+    });
+    const removeKeys = Array.from(prevPrices.current.keys()).filter(
+      (key) => !quotes.some((q) => q.symbol === key)
+    );
+    removeKeys.forEach((key) => {
+      prevPrices.current.delete(key);
+      const timer = timeoutRef.current.get(key);
+      if (timer) {
+        clearTimeout(timer);
+        timeoutRef.current.delete(key);
+      }
+    });
+  }, [quotes]);
+
+  useEffect(() => {
+    return () => {
+      timeoutRef.current.forEach((timer) => clearTimeout(timer));
+    };
+  }, []);
+
+  useEffect(() => {
+    if (quotes.length === 0) {
+      setFocusIndex(0);
+    } else if (focusIndex >= quotes.length) {
+      setFocusIndex(quotes.length - 1);
+    }
+  }, [focusIndex, quotes.length]);
+
+  const handleKey = (event: KeyboardEvent<HTMLTableSectionElement>) => {
+    if (quotes.length === 0) return;
+    if (event.key === "ArrowDown" || event.key.toLowerCase() === "j") {
+      event.preventDefault();
+      setFocusIndex((prev) => Math.min(prev + 1, quotes.length - 1));
+    } else if (event.key === "ArrowUp" || event.key.toLowerCase() === "k") {
+      event.preventDefault();
+      setFocusIndex((prev) => Math.max(prev - 1, 0));
+    } else if (event.key === "Enter") {
+      onSelect(quotes[focusIndex].symbol);
+    }
+  };
+
+  const activeSymbol = useMemo(() => quotes[focusIndex]?.symbol, [focusIndex, quotes]);
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-700 bg-surface/60">
+      <table className="w-full min-w-max table-fixed">
+        <thead className="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-400">
+          <tr>
+            <th className="px-4 py-3 text-left">代號</th>
+            <th className="px-4 py-3 text-right">最新價</th>
+            <th className="px-4 py-3 text-right">漲跌</th>
+            <th className="px-4 py-3 text-center">來源</th>
+            <th className="px-4 py-3 text-center">操作</th>
+          </tr>
+        </thead>
+        <tbody
+          className="divide-y divide-slate-800 text-sm"
+          tabIndex={0}
+          onKeyDown={handleKey}
+          aria-label="自選股列表"
+        >
+          {quotes.length === 0 && (
+            <tr>
+              <td colSpan={5} className="px-4 py-6 text-center text-slate-400">
+                尚未加入任何股票，請透過上方輸入框新增。
+              </td>
+            </tr>
+          )}
+          {quotes.map((quote) => {
+            const change = getChange(quote);
+            const direction = change.value > 0 ? "up" : change.value < 0 ? "down" : "flat";
+            const isFocused = activeSymbol === quote.symbol;
+            const flash = flashes[quote.symbol];
+            const hasAlerts = (alerts[quote.symbol] ?? []).some((alert) => alert.active);
+            return (
+              <tr
+                key={quote.symbol}
+                className={clsx(
+                  "cursor-pointer transition-colors focus-within:bg-slate-800/80",
+                  flash === "up" && "animate-flashGain",
+                  flash === "down" && "animate-flashLoss",
+                  direction === "up" && "text-emerald-300",
+                  direction === "down" && "text-rose-300"
+                )}
+                onClick={() => onSelect(quote.symbol)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    onSelect(quote.symbol);
+                  }
+                }}
+              >
+                <td
+                  className={clsx("px-4 py-3 text-left", isFocused && "bg-slate-800/40")}
+                  tabIndex={isFocused ? 0 : -1}
+                  aria-selected={isFocused}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold text-slate-100">{quote.symbol}</span>
+                    {hasAlerts && (
+                      <span className="rounded-full bg-amber-500/20 px-2 py-0.5 text-xs text-amber-300">
+                        告警
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-slate-500">更新：{formatTimestamp(quote.ts)}</p>
+                </td>
+                <td className="px-4 py-3 text-right text-slate-100">
+                  {formatPrice(quote.price)}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <div className="flex items-center justify-end gap-2">
+                    {direction === "up" && <ArrowTrendingUpIcon className="h-4 w-4" />}
+                    {direction === "down" && <ArrowTrendingDownIcon className="h-4 w-4" />}
+                    <span>{formatChange(change.value)}</span>
+                    <span className="text-xs text-slate-400">{formatPercent(change.pct)}</span>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-center text-xs uppercase text-slate-400">
+                  {quote.source}
+                </td>
+                <td className="px-4 py-3 text-center">
+                  <div className="flex items-center justify-center gap-2 text-slate-300">
+                    <button
+                      className="rounded-md border border-slate-600 px-2 py-1 text-xs hover:bg-slate-700"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onCreateAlert(quote.symbol);
+                      }}
+                    >
+                      <BellAlertIcon className="h-4 w-4" />
+                    </button>
+                    <button
+                      className="rounded-md border border-slate-600 px-2 py-1 text-xs hover:bg-slate-700"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onRemove(quote.symbol);
+                      }}
+                      aria-label={`移除 ${quote.symbol}`}
+                    >
+                      <TrashIcon className="h-4 w-4" />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/watchlist/watchlist-dashboard.tsx
+++ b/src/components/watchlist/watchlist-dashboard.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { ArrowPathIcon, LinkIcon, PlusIcon } from "@heroicons/react/24/outline";
+import clsx from "clsx";
+import { QuoteTable } from "./quote-table";
+import { useWatchlist } from "@/hooks/use-watchlist";
+import { useAlerts } from "@/hooks/use-alerts";
+import { useVisibilityAwareInterval } from "@/hooks/use-visibility-poll";
+import { useAudioAlert } from "@/hooks/use-audio-alert";
+import { Modal } from "@/components/ui/modal";
+import { CandlesChart } from "@/components/candles-chart";
+import { AlertCenter } from "@/components/alerts/alert-center";
+import { CreateAlertForm } from "@/components/alerts/create-alert-form";
+import { ToastStack } from "@/components/toast-stack";
+import { formatPrice } from "@/lib/format";
+import { sanitizeSymbols } from "@/lib/symbols";
+import type { CandlesResponse, Quote, QuotesResponse } from "@/lib/types";
+
+interface DashboardProps {
+  initialSymbols: string[];
+}
+
+interface ToastItem {
+  id: string;
+  title: string;
+  message: string;
+}
+
+const DEFAULT_INTERVAL = 60_000;
+const MAX_INTERVAL = 180_000;
+
+type SortKey = "symbol" | "price" | "change";
+
+type CandlesRange = "1d" | "5d";
+
+export function WatchlistDashboard({ initialSymbols }: DashboardProps) {
+  const { symbols, addSymbol, removeSymbol } = useWatchlist(initialSymbols);
+  const sanitizedSymbols = useMemo(() => sanitizeSymbols(symbols), [symbols]);
+  const { alerts, createAlert, toggleAlert, markTriggered, removeAlert, bySymbol } = useAlerts();
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("symbol");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+  const [inputSymbol, setInputSymbol] = useState("");
+  const [pollInterval, setPollInterval] = useState(DEFAULT_INTERVAL);
+  const { interval } = useVisibilityAwareInterval(pollInterval);
+  const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
+  const [range, setRange] = useState<CandlesRange>("1d");
+  const [alertSymbol, setAlertSymbol] = useState<string | null>(null);
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const [shareLink, setShareLink] = useState<string>("");
+  const [isMuted, setMuted] = useState(false);
+  const { play } = useAudioAlert();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (sanitizedSymbols.length > 0) {
+      url.searchParams.set("symbols", sanitizedSymbols.join(","));
+    } else {
+      url.searchParams.delete("symbols");
+    }
+    window.history.replaceState(null, "", url.toString());
+    setShareLink(url.toString());
+  }, [sanitizedSymbols]);
+
+  const quotesQuery = useQuery<QuotesResponse & { cached: boolean }>(
+    {
+      queryKey: ["quotes", sanitizedSymbols.join(",")],
+      queryFn: async () => {
+        if (sanitizedSymbols.length === 0) {
+          return { quotes: [], ts: Date.now(), cached: false };
+        }
+        const response = await fetch(`/api/quotes?symbols=${sanitizedSymbols.join(",")}`);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch quotes: ${response.status}`);
+        }
+        return (await response.json()) as QuotesResponse & { cached: boolean };
+      },
+      enabled: sanitizedSymbols.length > 0,
+      refetchInterval: interval === false ? false : interval,
+    }
+  );
+
+  useEffect(() => {
+    if (quotesQuery.isError) {
+      setPollInterval((prev) => Math.min(prev + 60_000, MAX_INTERVAL));
+    } else if (quotesQuery.isSuccess) {
+      setPollInterval(DEFAULT_INTERVAL);
+    }
+  }, [quotesQuery.isError, quotesQuery.isSuccess]);
+
+  useEffect(() => {
+    if (!quotesQuery.data) return;
+    quotesQuery.data.quotes.forEach((quote) => {
+      const rules = bySymbol[quote.symbol] ?? [];
+      rules.forEach((rule) => {
+        if (!rule.active) return;
+        if (!Number.isFinite(quote.price)) return;
+        if (
+          (rule.direction === "above" && quote.price >= rule.target) ||
+          (rule.direction === "below" && quote.price <= rule.target)
+        ) {
+          markTriggered(rule.id);
+          const id = cryptoRandomId();
+          setToasts((prev) => [
+            ...prev,
+            {
+              id,
+              title: `${quote.symbol} 告警觸發`,
+              message: `現價 ${formatPrice(quote.price)} 已達 ${rule.direction === "above" ? "高於" : "低於"} ${rule.target}`,
+            },
+          ]);
+          if (!isMuted) {
+            play();
+          }
+        }
+      });
+    });
+  }, [bySymbol, isMuted, markTriggered, play, quotesQuery.data]);
+
+  const filteredQuotes = useMemo(() => {
+    const dataset = quotesQuery.data?.quotes ?? [];
+    const filter = search.trim().toUpperCase();
+    const filtered = filter
+      ? dataset.filter((quote) => quote.symbol.includes(filter))
+      : dataset;
+    return [...filtered].sort((a, b) => sortQuotes(a, b, sortKey, sortDir));
+  }, [quotesQuery.data?.quotes, search, sortDir, sortKey]);
+
+  useEffect(() => {
+    if (selectedSymbol) {
+      setRange("1d");
+    }
+  }, [selectedSymbol]);
+
+  const candlesQuery = useQuery<CandlesResponse & { cached: boolean }>(
+    {
+      queryKey: ["candles", selectedSymbol, range],
+      queryFn: async () => {
+        if (!selectedSymbol) {
+          return { candles: [], source: "none", cached: false };
+        }
+        const response = await fetch(
+          `/api/candles?symbol=${selectedSymbol}&range=${range}`
+        );
+        if (!response.ok) {
+          throw new Error("Failed to fetch candles");
+        }
+        return (await response.json()) as CandlesResponse & { cached: boolean };
+      },
+      enabled: Boolean(selectedSymbol),
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  const handleAddSymbol = () => {
+    if (!inputSymbol.trim()) return;
+    try {
+      addSymbol(inputSymbol);
+      setInputSymbol("");
+    } catch (error) {
+      setToasts((prev) => [
+        ...prev,
+        {
+          id: cryptoRandomId(),
+          title: "加入失敗",
+          message: (error as Error).message,
+        },
+      ]);
+    }
+  };
+
+  const handleCreateAlert = (symbol: string) => {
+    setAlertSymbol(symbol);
+  };
+
+  const handleCopyShareLink = async () => {
+    if (!shareLink) return;
+    try {
+      await navigator.clipboard.writeText(shareLink);
+      setToasts((prev) => [
+        ...prev,
+        {
+          id: cryptoRandomId(),
+          title: "已複製分享連結",
+          message: shareLink,
+        },
+      ]);
+    } catch {
+      setToasts((prev) => [
+        ...prev,
+        {
+          id: cryptoRandomId(),
+          title: "複製失敗",
+          message: "請手動複製網址列。",
+        },
+      ]);
+    }
+  };
+
+  const statusBanner = renderStatusBanner(quotesQuery);
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-8">
+      <section>
+        <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-slate-100">自選股儀表板</h1>
+            <p className="text-sm text-slate-400">
+              透過 Finnhub / Yahoo Finance 來源，每分鐘自動更新。
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              className="inline-flex items-center gap-2 rounded-md border border-slate-600 px-4 py-2 text-sm text-slate-200 hover:bg-slate-700"
+              onClick={() => quotesQuery.refetch()}
+            >
+              <ArrowPathIcon className={clsx("h-4 w-4", quotesQuery.isFetching && "animate-spin")}
+              />
+              立即更新
+            </button>
+            <button
+              className="inline-flex items-center gap-2 rounded-md border border-slate-600 px-4 py-2 text-sm text-slate-200 hover:bg-slate-700"
+              onClick={handleCopyShareLink}
+            >
+              <LinkIcon className="h-4 w-4" />
+              分享連結
+            </button>
+            <button
+              className={clsx(
+                "inline-flex items-center gap-2 rounded-md border px-4 py-2 text-sm",
+                isMuted
+                  ? "border-rose-500/40 text-rose-300 hover:bg-rose-500/10"
+                  : "border-emerald-500/40 text-emerald-300 hover:bg-emerald-500/10"
+              )}
+              onClick={() => setMuted((prev) => !prev)}
+            >
+              {isMuted ? "音效關" : "音效開"}
+            </button>
+          </div>
+        </header>
+        <div className="mt-6 grid gap-4 md:grid-cols-[2fr_1fr]">
+          <div className="space-y-4">
+            <div className="flex flex-col gap-3 rounded-xl border border-slate-700 bg-surface/80 p-4 md:flex-row md:items-center md:justify-between">
+              <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                <div className="flex items-center gap-2">
+                  <input
+                    value={inputSymbol}
+                    onChange={(event) => setInputSymbol(event.target.value.toUpperCase())}
+                    placeholder="輸入股票代號"
+                    className="w-40 rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-accent focus:outline-none"
+                  />
+                  <button
+                    className="inline-flex items-center gap-2 rounded-md bg-accent px-3 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+                    onClick={handleAddSymbol}
+                  >
+                    <PlusIcon className="h-4 w-4" />
+                    新增
+                  </button>
+                </div>
+                <div className="flex items-center gap-2">
+                  <label className="text-xs text-slate-400" htmlFor="search">
+                    搜尋
+                  </label>
+                  <input
+                    id="search"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    className="w-40 rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-accent focus:outline-none"
+                  />
+                </div>
+              </div>
+              <div className="flex items-center gap-2 text-xs text-slate-400">
+                排序：
+                <button
+                  className={clsx(
+                    "rounded-md px-2 py-1",
+                    sortKey === "symbol" ? "bg-accent/40 text-slate-100" : "hover:bg-slate-700"
+                  )}
+                  onClick={() => toggleSort("symbol", setSortKey, setSortDir, sortKey, sortDir)}
+                >
+                  代號
+                </button>
+                <button
+                  className={clsx(
+                    "rounded-md px-2 py-1",
+                    sortKey === "price" ? "bg-accent/40 text-slate-100" : "hover:bg-slate-700"
+                  )}
+                  onClick={() => toggleSort("price", setSortKey, setSortDir, sortKey, sortDir)}
+                >
+                  價格
+                </button>
+                <button
+                  className={clsx(
+                    "rounded-md px-2 py-1",
+                    sortKey === "change" ? "bg-accent/40 text-slate-100" : "hover:bg-slate-700"
+                  )}
+                  onClick={() => toggleSort("change", setSortKey, setSortDir, sortKey, sortDir)}
+                >
+                  漲跌幅
+                </button>
+              </div>
+            </div>
+            {statusBanner}
+            <QuoteTable
+              quotes={filteredQuotes}
+              onSelect={setSelectedSymbol}
+              onRemove={removeSymbol}
+              onCreateAlert={handleCreateAlert}
+              alerts={bySymbol}
+            />
+          </div>
+          <AlertCenter
+            alerts={alerts}
+            onToggle={toggleAlert}
+            onRemove={removeAlert}
+          />
+        </div>
+      </section>
+
+      <Modal
+        open={Boolean(selectedSymbol)}
+        onClose={() => setSelectedSymbol(null)}
+        title={selectedSymbol ?? ""}
+      >
+        <div className="flex items-center gap-2">
+          <button
+            className={clsx(
+              "rounded-md px-3 py-1 text-sm",
+              range === "1d" ? "bg-accent text-white" : "bg-slate-700 text-slate-200"
+            )}
+            onClick={() => setRange("1d")}
+          >
+            1D
+          </button>
+          <button
+            className={clsx(
+              "rounded-md px-3 py-1 text-sm",
+              range === "5d" ? "bg-accent text-white" : "bg-slate-700 text-slate-200"
+            )}
+            onClick={() => setRange("5d")}
+          >
+            5D
+          </button>
+        </div>
+        <div className="mt-4">
+          {candlesQuery.isLoading && <p className="text-sm text-slate-400">載入中...</p>}
+          {candlesQuery.isError && (
+            <p className="text-sm text-rose-400">暫時無法取得分時資料，請稍後再試。</p>
+          )}
+          {candlesQuery.data && candlesQuery.data.candles.length > 0 ? (
+            <CandlesChart candles={candlesQuery.data.candles} />
+          ) : (
+            !candlesQuery.isLoading && (
+              <p className="rounded-md bg-slate-800/60 p-4 text-sm text-slate-300">
+                暫無分時資料。
+              </p>
+            )
+          )}
+          {candlesQuery.data && (
+            <p className="mt-4 text-xs text-slate-500">
+              資料來源：{candlesQuery.data.source}
+              {candlesQuery.data.cached && "（快取）"}
+            </p>
+          )}
+        </div>
+      </Modal>
+
+      <Modal
+        open={Boolean(alertSymbol)}
+        onClose={() => setAlertSymbol(null)}
+        title={alertSymbol ? `${alertSymbol} 告警` : ""}
+      >
+        {alertSymbol && (
+          <CreateAlertForm
+            symbol={alertSymbol}
+            onSubmit={(direction, target) => {
+              const rule = createAlert(alertSymbol, direction, target);
+              setToasts((prev) => [
+                ...prev,
+                {
+                  id: cryptoRandomId(),
+                  title: "告警建立成功",
+                  message: `${rule.symbol} ${rule.direction === "above" ? "高於" : "低於"} ${rule.target}`,
+                },
+              ]);
+              setAlertSymbol(null);
+            }}
+            onCancel={() => setAlertSymbol(null)}
+          />
+        )}
+      </Modal>
+
+      <ToastStack toasts={toasts} onDismiss={(id) => setToasts((prev) => prev.filter((toast) => toast.id !== id))} />
+    </main>
+  );
+}
+
+function cryptoRandomId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+function sortQuotes(a: Quote, b: Quote, key: SortKey, dir: "asc" | "desc") {
+  const factor = dir === "asc" ? 1 : -1;
+  if (key === "symbol") {
+    return a.symbol.localeCompare(b.symbol) * factor;
+  }
+  if (key === "price") {
+    return (Number(a.price) - Number(b.price)) * factor;
+  }
+  const changeA = Number(a.price) - Number(a.prevClose || 0);
+  const changeB = Number(b.price) - Number(b.prevClose || 0);
+  return (changeA - changeB) * factor;
+}
+
+function toggleSort(
+  key: SortKey,
+  setKey: (key: SortKey) => void,
+  setDir: (dir: "asc" | "desc") => void,
+  currentKey: SortKey,
+  currentDir: "asc" | "desc"
+) {
+  if (currentKey === key) {
+    setDir(currentDir === "asc" ? "desc" : "asc");
+  } else {
+    setKey(key);
+    setDir("asc");
+  }
+}
+
+function renderStatusBanner(
+  quotesQuery: UseQueryResult<QuotesResponse & { cached: boolean }>
+) {
+  if (quotesQuery.isLoading) {
+    return (
+      <div className="rounded-lg border border-slate-700 bg-slate-900/60 p-4 text-sm text-slate-300">
+        正在讀取最新報價...
+      </div>
+    );
+  }
+  if (quotesQuery.status === "idle") {
+    return null;
+  }
+  if (quotesQuery.isError) {
+    return (
+      <div className="rounded-lg border border-rose-500/50 bg-rose-900/40 p-4 text-sm text-rose-200">
+        資料來源暫時不可用，已暫停自動更新。
+      </div>
+    );
+  }
+  const data = quotesQuery.data;
+  if (!data) return null;
+  const hasError = data.quotes.some((quote) => quote.status === "error");
+  if (hasError || data.cached) {
+    return (
+      <div className="rounded-lg border border-amber-500/50 bg-amber-900/30 p-4 text-sm text-amber-200">
+        顯示快取資料，時間 {new Date(data.ts).toLocaleTimeString()}。來源可能暫時不穩定。
+      </div>
+    );
+  }
+  return null;
+}

--- a/src/hooks/use-alerts.ts
+++ b/src/hooks/use-alerts.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { v4 as uuid } from "uuid";
+import { useLocalStorage } from "./use-local-storage";
+import type { AlertRule } from "@/lib/types";
+
+const STORAGE_KEY = "watchlist-alerts";
+
+function ensureUuid() {
+  try {
+    return uuid();
+  } catch {
+    return Math.random().toString(36).slice(2);
+  }
+}
+
+export function useAlerts() {
+  const [alerts, setAlerts] = useLocalStorage<AlertRule[]>(STORAGE_KEY, []);
+
+  const createAlert = useCallback(
+    (symbol: string, direction: "above" | "below", target: number) => {
+      const rule: AlertRule = {
+        id: ensureUuid(),
+        symbol: symbol.toUpperCase(),
+        direction,
+        target,
+        active: true,
+        createdAt: Date.now(),
+      };
+      setAlerts([...alerts, rule]);
+      return rule;
+    },
+    [alerts, setAlerts]
+  );
+
+  const toggleAlert = useCallback(
+    (id: string, active: boolean) => {
+      setAlerts(alerts.map((alert) => (alert.id === id ? { ...alert, active } : alert)));
+    },
+    [alerts, setAlerts]
+  );
+
+  const markTriggered = useCallback(
+    (id: string) => {
+      setAlerts(
+        alerts.map((alert) =>
+          alert.id === id ? { ...alert, triggeredAt: Date.now(), active: false } : alert
+        )
+      );
+    },
+    [alerts, setAlerts]
+  );
+
+  const removeAlert = useCallback(
+    (id: string) => {
+      setAlerts(alerts.filter((alert) => alert.id !== id));
+    },
+    [alerts, setAlerts]
+  );
+
+  const bySymbol = useMemo(() => {
+    return alerts.reduce<Record<string, AlertRule[]>>((acc, alert) => {
+      const key = alert.symbol;
+      acc[key] = acc[key] ? [...acc[key], alert] : [alert];
+      return acc;
+    }, {});
+  }, [alerts]);
+
+  return { alerts, createAlert, toggleAlert, markTriggered, removeAlert, bySymbol } as const;
+}

--- a/src/hooks/use-audio-alert.ts
+++ b/src/hooks/use-audio-alert.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+
+export function useAudioAlert() {
+  const synthRef = useRef<AudioContext>();
+
+  const play = useCallback(() => {
+    if (typeof window === "undefined") return;
+    try {
+      if (!synthRef.current) {
+        synthRef.current = new AudioContext();
+      }
+      const synth = synthRef.current;
+      const oscillator = synth.createOscillator();
+      const gain = synth.createGain();
+      oscillator.type = "triangle";
+      oscillator.frequency.value = 880;
+      gain.gain.setValueAtTime(0.001, synth.currentTime);
+      gain.gain.exponentialRampToValueAtTime(0.1, synth.currentTime + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.001, synth.currentTime + 0.4);
+      oscillator.connect(gain);
+      gain.connect(synth.destination);
+      oscillator.start();
+      oscillator.stop(synth.currentTime + 0.5);
+    } catch (error) {
+      console.warn("Audio alert failed", error);
+    }
+  }, []);
+
+  return { play };
+}

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void] {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === "undefined") return initialValue;
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : initialValue;
+    } catch (error) {
+      console.warn(`Failed to read localStorage for ${key}`, error);
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(storedValue));
+    } catch (error) {
+      console.warn(`Failed to write localStorage for ${key}`, error);
+    }
+  }, [key, storedValue]);
+
+  return [storedValue, setStoredValue];
+}

--- a/src/hooks/use-visibility-poll.ts
+++ b/src/hooks/use-visibility-poll.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export function useVisibilityAwareInterval(baseInterval: number) {
+  const [interval, setIntervalValue] = useState<number | false>(baseInterval);
+  const visibilityRef = useRef<typeof document | null>(null);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    visibilityRef.current = document;
+    const handleVisibility = () => {
+      if (!visibilityRef.current) return;
+      setIntervalValue(visibilityRef.current.hidden ? false : baseInterval);
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    handleVisibility();
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [baseInterval]);
+
+  return { interval, setInterval: setIntervalValue };
+}

--- a/src/hooks/use-watchlist.ts
+++ b/src/hooks/use-watchlist.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useLocalStorage } from "./use-local-storage";
+import { sanitizeSymbols, validateSymbol } from "@/lib/symbols";
+
+const STORAGE_KEY = "watchlist-symbols";
+
+export function useWatchlist(initialSymbols: string[]) {
+  const sanitizedInitial = useMemo(() => sanitizeSymbols(initialSymbols), [initialSymbols]);
+  const [persisted, setPersisted] = useLocalStorage<string[]>(STORAGE_KEY, sanitizedInitial);
+  const [symbols, setSymbols] = useState<string[]>(() =>
+    Array.from(new Set([...(sanitizedInitial ?? []), ...(persisted ?? [])]))
+  );
+
+  useEffect(() => {
+    setSymbols((prev) => Array.from(new Set([...(prev ?? []), ...sanitizedInitial])));
+  }, [sanitizedInitial]);
+
+  useEffect(() => {
+    setPersisted(symbols);
+  }, [setPersisted, symbols]);
+
+  const addSymbol = useCallback((symbol: string) => {
+    const upper = symbol.trim().toUpperCase();
+    if (!validateSymbol(upper)) {
+      throw new Error("Invalid symbol format");
+    }
+    setSymbols((prev) => Array.from(new Set([...prev, upper])));
+  }, []);
+
+  const removeSymbol = useCallback((symbol: string) => {
+    const upper = symbol.toUpperCase();
+    setSymbols((prev) => prev.filter((item) => item !== upper));
+  }, []);
+
+  const clear = useCallback(() => {
+    setSymbols([]);
+  }, []);
+
+  return { symbols, addSymbol, removeSymbol, clear } as const;
+}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,50 @@
+export interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+  createdAt: number;
+}
+
+class MemoryCache {
+  private store = new Map<string, CacheEntry<unknown>>();
+
+  get<T>(key: string): CacheEntry<T> | undefined {
+    const entry = this.store.get(key) as CacheEntry<T> | undefined;
+    if (!entry) return undefined;
+    if (entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry;
+  }
+
+  set<T>(key: string, value: T, ttlMs: number): CacheEntry<T> {
+    const now = Date.now();
+    const entry: CacheEntry<T> = {
+      value,
+      expiresAt: now + ttlMs,
+      createdAt: now,
+    };
+    this.store.set(key, entry);
+    return entry;
+  }
+
+  delete(key: string) {
+    this.store.delete(key);
+  }
+
+  clear() {
+    this.store.clear();
+  }
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __MEMORY_CACHE__: MemoryCache | undefined;
+}
+
+const cache = globalThis.__MEMORY_CACHE__ ?? new MemoryCache();
+if (!globalThis.__MEMORY_CACHE__) {
+  globalThis.__MEMORY_CACHE__ = cache;
+}
+
+export default cache;

--- a/src/lib/candles.ts
+++ b/src/lib/candles.ts
@@ -1,0 +1,49 @@
+import cache from "./cache";
+import { getCacheTtl } from "./env";
+import { fetchFinnhubCandles, fetchYahooCandles } from "./sources";
+import type { CandlesResponse } from "./types";
+
+export async function getCandles(
+  symbol: string,
+  range: "1d" | "5d"
+): Promise<CandlesResponse & { cached: boolean }> {
+  const cacheKey = `candles:${symbol}:${range}`;
+  const ttl = getCacheTtl();
+  const cached = cache.get<CandlesResponse & { cached: boolean }>(cacheKey);
+  if (cached) {
+    return { ...cached.value, cached: true };
+  }
+
+  const result = await fetchCandles(symbol, range);
+  cache.set(cacheKey, { ...result, cached: false }, ttl);
+  return { ...result, cached: false };
+}
+
+async function fetchCandles(
+  symbol: string,
+  range: "1d" | "5d"
+): Promise<CandlesResponse> {
+  const errors: string[] = [];
+  try {
+    const finnhub = await fetchFinnhubCandles(symbol, range);
+    if (finnhub && finnhub.candles.length > 0) {
+      return finnhub;
+    }
+  } catch (err) {
+    errors.push((err as Error).message);
+  }
+
+  try {
+    const yahoo = await fetchYahooCandles(symbol, range);
+    if (yahoo.candles.length > 0) {
+      return yahoo;
+    }
+  } catch (err) {
+    errors.push((err as Error).message);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(errors.join("; "));
+  }
+  return { candles: [], source: "none" };
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,22 @@
+const DEFAULT_CACHE_TTL = 60_000;
+
+export function getFinnhubKey(): string | undefined {
+  const key = process.env.FINNHUB_API_KEY?.trim();
+  return key ? key : undefined;
+}
+
+export function getCacheTtl(): number {
+  const raw = process.env.CACHE_TTL_MS;
+  if (!raw) return DEFAULT_CACHE_TTL;
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_CACHE_TTL;
+}
+
+export function getAllowlist(): string[] | undefined {
+  const raw = process.env.ALLOWLIST_SYMBOLS;
+  if (!raw) return undefined;
+  return raw
+    .split(",")
+    .map((s) => s.trim().toUpperCase())
+    .filter(Boolean);
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,35 @@
+import type { Quote } from "./types";
+
+export function formatPrice(value: number): string {
+  if (!Number.isFinite(value)) return "-";
+  return value.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+export function getChange(quote: Quote): { value: number; pct: number } {
+  if (!Number.isFinite(quote.price) || !Number.isFinite(quote.prevClose)) {
+    return { value: NaN, pct: NaN };
+  }
+  const value = quote.price - quote.prevClose;
+  const pct = quote.prevClose === 0 ? 0 : (value / quote.prevClose) * 100;
+  return { value, pct };
+}
+
+export function formatChange(value: number): string {
+  if (!Number.isFinite(value)) return "-";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}`;
+}
+
+export function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) return "-";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+export function formatTimestamp(ts: number): string {
+  if (!Number.isFinite(ts)) return "-";
+  return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}

--- a/src/lib/quotes.ts
+++ b/src/lib/quotes.ts
@@ -1,0 +1,90 @@
+import cache from "./cache";
+import { getAllowlist, getCacheTtl } from "./env";
+import { sanitizeSymbols } from "./symbols";
+import { fetchFinnhubQuote, fetchYahooQuotes } from "./sources";
+import type { Quote, QuotesResponse } from "./types";
+
+const MAX_SYMBOLS = 50;
+
+export async function getQuotes(symbols: string[]): Promise<QuotesResponse> {
+  const allowedSymbols = filterAllowlist(symbols);
+  if (allowedSymbols.length === 0) {
+    return { quotes: [], ts: Date.now(), cached: false };
+  }
+  if (allowedSymbols.length > MAX_SYMBOLS) {
+    throw new Error(`Too many symbols. Maximum is ${MAX_SYMBOLS}.`);
+  }
+  const normalized = sanitizeSymbols(allowedSymbols);
+  const cacheKey = `quotes:${normalized.join(",")}`;
+  const ttl = getCacheTtl();
+  const cached = cache.get<QuotesResponse>(cacheKey);
+  if (cached) {
+    return { ...cached.value, cached: true };
+  }
+
+  const quotes: Quote[] = [];
+  const errors: string[] = [];
+  const missing = new Set(normalized);
+  try {
+    const keyAvailable = Boolean(process.env.FINNHUB_API_KEY);
+    if (keyAvailable) {
+      await Promise.all(
+        normalized.map(async (symbol) => {
+          try {
+            const quote = await fetchFinnhubQuote(symbol);
+            if (quote) {
+              quotes.push(quote);
+              missing.delete(symbol);
+            }
+          } catch (err) {
+            errors.push(`${symbol}: ${(err as Error).message}`);
+          }
+        })
+      );
+    }
+  } catch (err) {
+    errors.push((err as Error).message);
+  }
+
+  if (missing.size > 0) {
+    try {
+      const yahooQuotes = await fetchYahooQuotes(Array.from(missing));
+      yahooQuotes.forEach((quote) => {
+        quotes.push(quote);
+        missing.delete(quote.symbol);
+      });
+    } catch (err) {
+      errors.push((err as Error).message);
+    }
+  }
+
+  const now = Date.now();
+  const result: QuotesResponse = {
+    quotes: normalized.map((symbol) => {
+      const quote = quotes.find((item) => item.symbol === symbol);
+      if (!quote) {
+        return {
+          symbol,
+          price: NaN,
+          prevClose: NaN,
+          ts: now,
+          source: errors.length > 0 ? "cache" : "yahoo",
+          status: "error" as const,
+        };
+      }
+      return quote;
+    }),
+    ts: now,
+    cached: false,
+  };
+
+  cache.set(cacheKey, result, ttl);
+  return result;
+}
+
+function filterAllowlist(symbols: string[]): string[] {
+  const allowlist = getAllowlist();
+  if (!allowlist || allowlist.length === 0) return symbols;
+  const set = new Set(allowlist);
+  return symbols.filter((symbol) => set.has(symbol.toUpperCase()));
+}

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -1,0 +1,152 @@
+import { getFinnhubKey } from "./env";
+import type { Candle, CandlesResponse, Quote } from "./types";
+
+const FINNHUB_BASE = "https://finnhub.io/api/v1";
+const YAHOO_QUOTE_ENDPOINT = "https://query1.finance.yahoo.com/v7/finance/quote";
+const YAHOO_CHART_ENDPOINT = "https://query1.finance.yahoo.com/v8/finance/chart";
+
+interface FinnhubQuotePayload {
+  c: number;
+  pc: number;
+  t: number;
+}
+
+interface YahooQuotePayload {
+  symbol: string;
+  regularMarketPrice: number;
+  regularMarketPreviousClose: number;
+  regularMarketTime: number;
+}
+
+export async function fetchFinnhubQuote(symbol: string): Promise<Quote | undefined> {
+  const key = getFinnhubKey();
+  if (!key) return undefined;
+  const url = `${FINNHUB_BASE}/quote?symbol=${encodeURIComponent(symbol)}&token=${key}`;
+  const res = await fetch(url, { next: { revalidate: 0 } });
+  if (!res.ok) {
+    throw new Error(`Finnhub quote failed: ${res.status}`);
+  }
+  const data = (await res.json()) as FinnhubQuotePayload;
+  if (typeof data.c !== "number" || typeof data.pc !== "number") {
+    throw new Error("Invalid Finnhub payload");
+  }
+  return {
+    symbol,
+    price: data.c,
+    prevClose: data.pc,
+    ts: (data.t ?? Date.now() / 1000) * 1000,
+    source: "finnhub",
+    status: "ok",
+  };
+}
+
+export async function fetchYahooQuotes(symbols: string[]): Promise<Quote[]> {
+  if (symbols.length === 0) return [];
+  const url = `${YAHOO_QUOTE_ENDPOINT}?symbols=${encodeURIComponent(symbols.join(","))}`;
+  const res = await fetch(url, { next: { revalidate: 0 } });
+  if (!res.ok) {
+    throw new Error(`Yahoo quote failed: ${res.status}`);
+  }
+  const payload = (await res.json()) as {
+    quoteResponse?: { result?: YahooQuotePayload[] };
+  };
+  const items = payload.quoteResponse?.result ?? [];
+  return items
+    .filter((item) =>
+      typeof item.regularMarketPrice === "number" &&
+      typeof item.regularMarketPreviousClose === "number"
+    )
+    .map((item) => ({
+      symbol: item.symbol.toUpperCase(),
+      price: item.regularMarketPrice,
+      prevClose: item.regularMarketPreviousClose,
+      ts: (item.regularMarketTime ?? Date.now() / 1000) * 1000,
+      source: "yahoo" as const,
+      status: "ok" as const,
+    }));
+}
+
+interface FinnhubCandlePayload {
+  t: number[];
+  o: number[];
+  h: number[];
+  l: number[];
+  c: number[];
+  v?: number[];
+  s?: string;
+}
+
+export async function fetchFinnhubCandles(
+  symbol: string,
+  range: "1d" | "5d"
+): Promise<CandlesResponse | undefined> {
+  const key = getFinnhubKey();
+  if (!key) return undefined;
+  const resolution = range === "1d" ? "1" : "5";
+  const now = Math.floor(Date.now() / 1000);
+  const from = range === "1d" ? now - 60 * 60 * 24 : now - 60 * 60 * 24 * 5;
+  const url = `${FINNHUB_BASE}/stock/candle?symbol=${encodeURIComponent(
+    symbol
+  )}&resolution=${resolution}&from=${from}&to=${now}&token=${key}`;
+  const res = await fetch(url, { next: { revalidate: 0 } });
+  if (!res.ok) {
+    throw new Error(`Finnhub candle failed: ${res.status}`);
+  }
+  const data = (await res.json()) as FinnhubCandlePayload;
+  if (data.s !== "ok" || !Array.isArray(data.t)) {
+    throw new Error("Invalid Finnhub candle payload");
+  }
+  const candles: Candle[] = data.t.map((timestamp, index) => ({
+    t: timestamp * 1000,
+    o: data.o[index],
+    h: data.h[index],
+    l: data.l[index],
+    c: data.c[index],
+    v: data.v?.[index],
+  }));
+  return { candles, source: "finnhub" };
+}
+
+interface YahooCandlePayload {
+  chart?: {
+    result?: Array<{
+      timestamp?: number[];
+      indicators?: {
+        quote?: Array<{
+          open?: number[];
+          high?: number[];
+          low?: number[];
+          close?: number[];
+          volume?: number[];
+        }>;
+      };
+    }>;
+  };
+}
+
+export async function fetchYahooCandles(
+  symbol: string,
+  range: "1d" | "5d"
+): Promise<CandlesResponse> {
+  const interval = range === "1d" ? "1m" : "5m";
+  const url = `${YAHOO_CHART_ENDPOINT}/${encodeURIComponent(
+    symbol
+  )}?range=${range}&interval=${interval}`;
+  const res = await fetch(url, { next: { revalidate: 0 } });
+  if (!res.ok) {
+    throw new Error(`Yahoo candle failed: ${res.status}`);
+  }
+  const data = (await res.json()) as YahooCandlePayload;
+  const result = data.chart?.result?.[0];
+  const timestamps = result?.timestamp ?? [];
+  const quotes = result?.indicators?.quote?.[0];
+  const candles: Candle[] = timestamps.map((ts, index) => ({
+    t: ts * 1000,
+    o: quotes?.open?.[index] ?? 0,
+    h: quotes?.high?.[index] ?? 0,
+    l: quotes?.low?.[index] ?? 0,
+    c: quotes?.close?.[index] ?? 0,
+    v: quotes?.volume?.[index],
+  }));
+  return { candles, source: "yahoo" };
+}

--- a/src/lib/symbols.ts
+++ b/src/lib/symbols.ts
@@ -1,0 +1,22 @@
+const SYMBOL_REGEX = /^[A-Z0-9_.-]{1,8}$/;
+
+export function normalizeSymbols(raw: string): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .split(",")
+        .map((s) => s.trim().toUpperCase())
+        .filter(Boolean)
+    )
+  );
+}
+
+export function validateSymbol(symbol: string): boolean {
+  return SYMBOL_REGEX.test(symbol.toUpperCase());
+}
+
+export function sanitizeSymbols(symbols: string[]): string[] {
+  return Array.from(new Set(symbols.map((s) => s.trim().toUpperCase()))).filter(
+    (s) => SYMBOL_REGEX.test(s)
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,41 @@
+export type QuoteSource = "finnhub" | "yahoo" | "cache";
+export type QuoteStatus = "ok" | "stale" | "error";
+
+export interface Quote {
+  symbol: string;
+  price: number;
+  prevClose: number;
+  ts: number;
+  source: QuoteSource;
+  status: QuoteStatus;
+}
+
+export interface QuotesResponse {
+  quotes: Quote[];
+  ts: number;
+  cached: boolean;
+}
+
+export interface Candle {
+  t: number;
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+  v?: number;
+}
+
+export interface CandlesResponse {
+  candles: Candle[];
+  source: Exclude<QuoteSource, "cache"> | "none";
+}
+
+export interface AlertRule {
+  id: string;
+  symbol: string;
+  direction: "above" | "below";
+  target: number;
+  active: boolean;
+  createdAt: number;
+  triggeredAt?: number;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,38 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "#0b1220",
+        surface: "#111b2f",
+        accent: "#1f4cff",
+        gain: "#29d38f",
+        loss: "#ff5d73",
+      },
+      keyframes: {
+        flashGain: {
+          "0%": { backgroundColor: "rgba(41, 211, 143, 0.2)" },
+          "100%": { backgroundColor: "transparent" },
+        },
+        flashLoss: {
+          "0%": { backgroundColor: "rgba(255, 93, 115, 0.2)" },
+          "100%": { backgroundColor: "transparent" },
+        },
+      },
+      animation: {
+        flashGain: "flashGain 0.8s ease-out",
+        flashLoss: "flashLoss 0.8s ease-out",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "es2017"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: [],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold a Next.js app router project with Tailwind, React Query, and Vitest tooling
- add `/api/quotes` and `/api/candles` routes that cache Finnhub/Yahoo responses with fallback logic
- build the client watchlist dashboard with polling, modal candles, alerts, sharing, and local persistence
- document setup, env vars, tests, and provide demo recording guidance

## Testing
- not run (node modules unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df3a99a81c8327ab610fce31c19b74